### PR TITLE
A simple commit to add composer-generated files to the gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 build
+composer.lock
+vendor/


### PR DESCRIPTION
After running `composer.phar install`, I noticed that git showed composer.lock and vendor/ as untracked files, so I added them to .gitignore.
