### PR TITLE
testXmlPrettyPrintResponse() for code completeness

### DIFF
--- a/tests/Hal/HalTest.php
+++ b/tests/Hal/HalTest.php
@@ -63,6 +63,21 @@ class HalTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('My Test', $data['title']);
     }
 
+    public function testXmlPrettyPrintResponse()
+    {
+        $hal = new Hal('http://example.com/');
+        $hal->addLink('test', '/test/1', 'My Test');
+
+        $response = <<<EOD
+<?xml version="1.0"?>
+<resource href="http://example.com/">
+  <link rel="test" href="/test/1" title="My Test"/>
+</resource>
+
+EOD;
+        $this->assertEquals($response, $hal->asXml(true));
+    }
+
     public function testResourceJsonResponse()
     {
         $hal = new Hal('http://example.com/');


### PR DESCRIPTION
When reviewing the code coverage report, I noticed that lines 44-45 in src/Nocarrier/HalXmlRenderer.php were not being tested, since no test was setting $pretty to true in `asXml()`, so I wrote a test to cover these lines.
