### PR TITLE
Fix for warnings when outputting XML with Resources that contain ampersands

### DIFF
--- a/src/Nocarrier/HalXmlRenderer.php
+++ b/src/Nocarrier/HalXmlRenderer.php
@@ -99,10 +99,10 @@ class HalXmlRenderer implements HalRenderer
                     if (substr($key, 0, 1) === '@') {
                         $element->addAttribute(substr($key, 1), $value);
                     } else {
-                        $element->addChild($key, $value);
+                        $element->addChild($key, htmlentities($value));
                     }
                 } else {
-                    $element->addChild($parent, $value);
+                    $element->addChild($parent, htmlentities($value));
                 }
             }
         }


### PR DESCRIPTION
When creating a resource with an ampersand in one of the properties a warning will be outputted when trying to render it as XML. This is because SimpleXml expects all special characters to be encoded.

fixed by running htmlentities over the $value.
