### PR TITLE
Replace htmlentities with htmlspecialchars

### DIFF
--- a/src/Nocarrier/HalXmlRenderer.php
+++ b/src/Nocarrier/HalXmlRenderer.php
@@ -99,10 +99,10 @@ class HalXmlRenderer implements HalRenderer
                     if (substr($key, 0, 1) === '@') {
                         $element->addAttribute(substr($key, 1), $value);
                     } else {
-                        $element->addChild($key, htmlentities($value));
+                        $element->addChild($key, htmlspecialchars($value, ENT_QUOTES));
                     }
                 } else {
-                    $element->addChild($parent, htmlentities($value));
+                    $element->addChild($parent, htmlspecialchars($value, ENT_QUOTES));
                 }
             }
         }


### PR DESCRIPTION
htmlentities generates output that contains invalid XML entities (like &Atilde; for example), use htmlspecialchars instead which only converts the 5 entities known by the XML spec. http://www.w3.org/TR/xml/#sec-predefined-ent
