### PR TITLE
Parse embedded resources when unserializing from JSON

### DIFF
--- a/src/Nocarrier/Hal.php
+++ b/src/Nocarrier/Hal.php
@@ -117,7 +117,7 @@ class Hal
 
         if ($max_depth > 0) {
             foreach ($embedded as $rel => $embed) {
-                $hal->addResource($rel, $this->jsonToHal(json_encode($embed), $max_depth - 1));
+                $hal->addResource($rel, $this->fromJson(json_encode($embed), $max_depth - 1));
             }
         }
 


### PR DESCRIPTION
This is a very simple solution to https://github.com/blongden/hal/issues/14

I do like some of the things happening in https://github.com/blongden/hal/pull/19 (specifically, checking for valid Hal while parsing), and this change shouldn't obstruct any of that work.
