### PR TITLE
Fix multiple embedded resources (see blongden/hal#14).

### DIFF
--- a/src/Nocarrier/Hal.php
+++ b/src/Nocarrier/Hal.php
@@ -117,7 +117,13 @@ class Hal
 
         if ($max_depth > 0) {
             foreach ($embedded as $rel => $embed) {
-                $hal->addResource($rel, $this->fromJson(json_encode($embed), $max_depth - 1));
+                if (!is_array($embed)) {
+                    $hal->addResource($rel, self::fromJson(json_encode($embed), $max_depth - 1));
+                } else {
+                    foreach ($embed as $child_resource) {
+                        $hal->addResource($rel, self::fromJson(json_encode($child_resource), $max_depth - 1));
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
When a HAL response contains multiple embedded resources of the same
'rel', they are parsed at once.

This fails, as it is an array with separate valid HAL resources in it.
This is fixed by checking if the embeds are an array, and if so, adding
the resources one-by-one.

This is related to blongden/hal#14.
