### PR TITLE
Allow Traversables as Hal data.

### DIFF
--- a/src/Nocarrier/Hal.php
+++ b/src/Nocarrier/Hal.php
@@ -75,11 +75,18 @@ class Hal
      * representation. This will not affect the JSON representation.
      *
      * @param mixed $uri
-     * @param array $data
+     * @param array|Traversable $data
+     *
+     * @throws \RuntimeException
      */
-    public function __construct($uri = null, array $data = array())
+    public function __construct($uri = null, $data = array())
     {
         $this->uri = $uri;
+
+        if (!is_array($data) && !$data instanceof \Traversable) {
+            throw new \RuntimeException(
+                'The $data parameter must be an array or an object implementing the Traversable interface.');
+        }
         $this->data = $data;
 
         $this->links = new HalLinkContainer();

--- a/src/Nocarrier/HalXmlRenderer.php
+++ b/src/Nocarrier/HalXmlRenderer.php
@@ -82,10 +82,10 @@ class HalXmlRenderer implements HalRenderer
      * @access protected
      * @return void
      */
-    protected function arrayToXml(array $data, \SimpleXmlElement $element, $parent = null)
+    protected function arrayToXml($data, \SimpleXmlElement $element, $parent = null)
     {
         foreach ($data as $key => $value) {
-            if (is_array($value)) {
+            if (is_array($value) || $value instanceof \Traversable) {
                 if (!is_numeric($key)) {
                     if (count($value) > 0 && isset($value[0])) {
                         $this->arrayToXml($value, $element, $key);

--- a/tests/Hal/HalTest.php
+++ b/tests/Hal/HalTest.php
@@ -561,4 +561,17 @@ EOD;
         $data = json_decode($x->asJson());
         $this->assertEquals('http://test', $data->_links->testrel->href);
     }
+
+    public function testDataCanBeTraversable()
+    {
+        $it = new \ArrayIterator(array('traversable' => new \ArrayIterator(array('key' => 'value'))));
+        $x = new Hal('', $it);
+
+        $response = <<<EOD
+<?xml version="1.0"?>
+<resource href=""><traversable><key>value</key></traversable></resource>
+
+EOD;
+        $this->assertEquals($response, $x->asXml());
+    }
 }


### PR DESCRIPTION
By allowing Traversables as data, it is possible to use Iterators and Collection objects as input, without having to parse them to an array first.
