### PR TITLE
Throw a runtimeException if data passed to fromJson method isn't json

### DIFF
--- a/src/Nocarrier/Hal.php
+++ b/src/Nocarrier/Hal.php
@@ -97,6 +97,9 @@ class Hal
     public static function fromJson($text, $max_depth = 0)
     {
         $data = json_decode($text, true);
+        if (is_null($data)) {
+            throw new \RuntimeException('Data passed is not valid JSON');
+        }
         $uri = $data['_links']['self']['href'];
         unset ($data['_links']['self']);
 


### PR DESCRIPTION
Avoids the error `Fatal Error: 'Argument 2 passed to CG\Slim\Renderer\ResponseType\Hal::__construct() must be of the type array, null given, called in /var/www/app/current/vendor/nocarrier/hal/src/Nocarrier/Hal.php on line 116`
