### PR TITLE
Throw a runtimeException if data passed to fromJson method isn't json

### DIFF
--- a/src/Nocarrier/JsonHalFactory.php
+++ b/src/Nocarrier/JsonHalFactory.php
@@ -29,6 +29,9 @@ class JsonHalFactory
     private static function prepareJsonData($text)
     {
         $data = json_decode($text, true);
+        if (json_last_error() != JSON_ERROR_NONE) {
+            throw new \RuntimeException('The $text parameter must be valid JSON');
+        }
         $uri = isset($data['_links']['self']['href']) ? $data['_links']['self']['href'] : "";
         unset ($data['_links']['self']);
 

--- a/tests/Hal/HalTest.php
+++ b/tests/Hal/HalTest.php
@@ -702,4 +702,13 @@ JSON;
 
         $this->assertEquals($res1, $hal->getFirstResource("resource"));
     }
+
+    /**
+     * @expectedException RuntimeException
+     */
+    public function testHalFromJsonThrowsExceptionOnInvalidJSON()
+    {
+        $invalidJson = 'foo';
+        Hal::fromJson($invalidJson);
+    }
 }


### PR DESCRIPTION
Avoids the error `Fatal Error: 'Argument 2 passed to CG\Slim\Renderer\ResponseType\Hal::__construct() must be of the type array, null given, called in /var/www/app/current/vendor/nocarrier/hal/src/Nocarrier/Hal.php on line 116`
