### PR TITLE
Allow json to show one rel as an array instead of an object

### DIFF
--- a/src/Nocarrier/Hal.php
+++ b/src/Nocarrier/Hal.php
@@ -59,6 +59,13 @@ class Hal
     protected $links = null;
 
     /**
+     * A list of rel types for links that will force a rel type to array for one element
+     *
+     * @var array 
+     */
+    protected $arrayLinkRels = array();
+
+    /**
      * Construct a new Hal object from an array of data. You can markup the
      * $data array with certain keys and values in order to affect the
      * generated JSON or XML documents if required to do so.
@@ -127,11 +134,16 @@ class Hal
      * @param string $uri
      * @param array $attributes
      *   Other attributes, as defined by HAL spec and RFC 5988.
+     * @param bool $forceArray whether to force a rel to be an array if it has only one entry
      * @return \Nocarrier\Hal
      */
-    public function addLink($rel, $uri, array $attributes = array())
+    public function addLink($rel, $uri, array $attributes = array(), $forceArray = false)
     {
         $this->links[$rel][] = new HalLink($uri, $attributes);
+
+        if ($forceArray) {
+            $this->arrayLinkRels[] = $rel;
+        }
 
         return $this;
     }
@@ -147,7 +159,7 @@ class Hal
     public function addResource($rel, \Nocarrier\Hal $resource = null)
     {
         $this->resources[$rel][] = $resource;
-
+        
         return $this;
     }
 
@@ -331,5 +343,13 @@ class Hal
     public function addCurie($name, $uri)
     {
         return $this->addLink('curies', $uri, array('name' => $name, 'templated' => true));
+    }
+
+    /**
+     * Get a list of rel types for links that will be forced to an array for one element
+     */
+    public function getArrayLinkRels()
+    {
+        return $this->arrayLinkRels;
     }
 }

--- a/src/Nocarrier/HalJsonRenderer.php
+++ b/src/Nocarrier/HalJsonRenderer.php
@@ -50,14 +50,14 @@ class HalJsonRenderer implements HalRenderer
      * @param array $links
      * @return array
      */
-    protected function linksForJson($uri, $links)
+    protected function linksForJson($uri, $links, $arrayLinkRels)
     {
         $data = array();
         if (!is_null($uri)) {
             $data['self'] = array('href' => $uri);
         }
         foreach ($links as $rel => $links) {
-            if (count($links) === 1 && $rel !== 'curies') {
+            if (count($links) === 1 && $rel !== 'curies' && !in_array($rel, $arrayLinkRels)) {
                 $data[$rel] = array('href' => $links[0]->getUri());
                 foreach ($links[0]->getAttributes() as $attribute => $value) {
                     $data[$rel][$attribute] = $value;
@@ -146,7 +146,7 @@ class HalJsonRenderer implements HalRenderer
         $data = $resource->getData();
         $data = $this->stripAttributeMarker($data);
 
-        $links = $this->linksForJson($resource->getUri(), $resource->getLinks());
+        $links = $this->linksForJson($resource->getUri(), $resource->getLinks(), $resource->getArrayLinkRels());
         if (count($links)) {
             $data['_links'] = $links;
         }

--- a/tests/Hal/HalTest.php
+++ b/tests/Hal/HalTest.php
@@ -59,6 +59,16 @@ class HalTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('/test/1', $result->_links->test->href);
     }
 
+    public function testAddLinkRelAsArrayJsonResponse()
+    {
+        $hal = new Hal('http://example.com/');
+        $hal->addLink('test', '/test/1', array(), true);
+        $json =  $hal->asJson();
+        $expectedJson = '{"_links":{"self":{"href":"http:\/\/example.com\/"},"test":[{"href":"\/test\/1"}]}}';
+        $this->assertEquals($json,$expectedJson);
+    }
+
+
     public function testAddLinkXmlResponse()
     {
         $hal = new Hal('http://example.com/');


### PR DESCRIPTION
According to [The Hal Specification](http://stateless.co/hal_specification.html), "A resource may have multiple links that share the same link relation. ... If you're unsure whether the link should be singular, assume it will be multiple. If you pick singular and find you need to change it, you will need to create a new link relation or face breaking existing clients."

This code change allows you to specify when you add a link that the rel should be forced to an array, even if only one element is available.

```
$hal->addLink( $rel, $url, $properties, $forceArray);
```
