### PR TITLE
Skip stripping attributes for HAL resources from JSON

### DIFF
--- a/src/Nocarrier/Hal.php
+++ b/src/Nocarrier/Hal.php
@@ -61,16 +61,23 @@ class Hal
     /**
      * A list of rel types for links that will force a rel type to array for one element
      *
-     * @var array 
+     * @var array
      */
     protected $arrayLinkRels = array();
-    
+
     /**
      * A list of rel types for links that will force a rel type to array for one element
      *
-     * @var array 
+     * @var array
      */
     protected $arrayResourceRels = array();
+
+    /**
+     * Whether xml attribute markers should be stripped when rendering
+     *
+     * @var string
+     */
+    protected $shouldStripAttributes = true;
 
     /**
      * Construct a new Hal object from an array of data. You can markup the
@@ -170,7 +177,7 @@ class Hal
         if ($forceArray) {
             $this->arrayResourceRels[] = $rel;
         }
-        
+
         return $this;
     }
 
@@ -371,4 +378,16 @@ class Hal
     {
         return $this->arrayResourceRels;
     }
+
+    public function getShouldStripAttributes()
+    {
+        return $this->shouldStripAttributes;
+    }
+
+    public function setShouldStripAttributes($shouldStripAttributes)
+    {
+        $this->shouldStripAttributes = $shouldStripAttributes;
+        return $this;
+    }
+
 }

--- a/src/Nocarrier/HalJsonRenderer.php
+++ b/src/Nocarrier/HalJsonRenderer.php
@@ -144,7 +144,9 @@ class HalJsonRenderer implements HalRenderer
         }
 
         $data = $resource->getData();
-        $data = $this->stripAttributeMarker($data);
+        if ($resource->getShouldStripAttributes()) {
+            $data = $this->stripAttributeMarker($data);
+        }
 
         $links = $this->linksForJson($resource->getUri(), $resource->getLinks(), $resource->getArrayLinkRels());
         if (count($links)) {
@@ -155,7 +157,7 @@ class HalJsonRenderer implements HalRenderer
             $embedded = $this->resourcesForJson($resources);
             if (count($embedded) === 1 && !in_array($rel, $resource->getArrayResourceRels())) {
                 $embedded = $embedded[0];
-            } 
+            }
             $data['_embedded'][$rel] = $embedded;
         }
 

--- a/src/Nocarrier/JsonHalFactory.php
+++ b/src/Nocarrier/JsonHalFactory.php
@@ -22,7 +22,7 @@ class JsonHalFactory
         if ($depth > 0) {
             self::setEmbeddedResources($hal, $embedded, $depth);
         }
-
+        $hal->setShouldStripAttributes(false);
         return $hal;
     }
 

--- a/src/Nocarrier/XmlHalFactory.php
+++ b/src/Nocarrier/XmlHalFactory.php
@@ -51,7 +51,7 @@ class XmlHalFactory
                 $hal->addResource($rel, self::fromXml($embed, $depth - 1));
             }
         }
-
+        $hal->setShouldStripAttributes(false);
         return $hal;
     }
 


### PR DESCRIPTION
If the HAL object wasn't created from XML there shouldn't be any attributes to strip. As we can't be sure that
all resources have a source format set, we can only test that the format has been set and it's not XML.

For large collections we see a not insignificant overhead when stripping attributes and this seemed the cleanest way to identify cases where there weren't attributes to strip.

Existing tests cover that XML still attributes still get stripped where no source is set, so there should be no BC breaks.
