### PR TITLE
Fix missing doc for param in HalJsonRenderer

### DIFF
--- a/src/Nocarrier/HalJsonRenderer.php
+++ b/src/Nocarrier/HalJsonRenderer.php
@@ -25,6 +25,7 @@ class HalJsonRenderer implements HalRenderer
      *
      * @param \Nocarrier\Hal $resource
      * @param bool $pretty
+     * @param bool $encode
      * @return string
      */
     public function render(Hal $resource, $pretty, $encode = true)


### PR DESCRIPTION
Just fixed missing doc for $encode parameter in HalJsonRenderer.php
Please merge if its correct.