### PR TITLE
Allow setting links by passing a link instance

### DIFF
--- a/src/Nocarrier/Hal.php
+++ b/src/Nocarrier/Hal.php
@@ -153,7 +153,20 @@ class Hal
      */
     public function addLink($rel, $uri, array $attributes = array(), $forceArray = false)
     {
-        $this->links[$rel][] = new HalLink($uri, $attributes);
+        return $this->setLink($rel, new HalLink($uri, $attributes), $forceArray);
+    }
+
+    /**
+     * Set a link instance to the resource, identified by $rel.
+     *
+     * @param string $rel
+     * @param HalLink $link
+     * @param bool $forceArray whether to force a rel to be an array if it has only one entry
+     * @return \Nocarrier\Hal
+     */
+    public function setLink($rel, HalLink $link, $forceArray = false)
+    {
+        $this->links[$rel][] = $link;
 
         if ($forceArray) {
             $this->arrayLinkRels[] = $rel;
@@ -294,7 +307,7 @@ class Hal
 
         return null;
     }
-    
+
     /**
      * Get the first link for a given rel. Useful if you're only expecting
      * one link, or you don't care about subsequent links

--- a/src/Nocarrier/Hal.php
+++ b/src/Nocarrier/Hal.php
@@ -153,18 +153,18 @@ class Hal
      */
     public function addLink($rel, $uri, array $attributes = array(), $forceArray = false)
     {
-        return $this->setLink($rel, new HalLink($uri, $attributes), $forceArray);
+        return $this->addHalLink($rel, new HalLink($uri, $attributes), $forceArray);
     }
 
     /**
-     * Set a link instance to the resource, identified by $rel.
+     * Add a link instance to the resource, identified by $rel.
      *
      * @param string $rel
      * @param HalLink $link
      * @param bool $forceArray whether to force a rel to be an array if it has only one entry
      * @return \Nocarrier\Hal
      */
-    public function setLink($rel, HalLink $link, $forceArray = false)
+    public function addHalLink($rel, HalLink $link, $forceArray = false)
     {
         $this->links[$rel][] = $link;
 

--- a/tests/Hal/HalTest.php
+++ b/tests/Hal/HalTest.php
@@ -276,6 +276,7 @@ EOD;
 
     /**
      * @covers \Nocarrier\Hal::addLink
+     * @covers \Nocarrier\Hal::addHalLink
      * @covers \Nocarrier\HalJsonRenderer::linksForJson
      */
     public function testLinkAttributesInJson()
@@ -345,6 +346,7 @@ EOD;
 
     /**
      * @covers \Nocarrier\Hal::addLink
+     * @covers \Nocarrier\Hal::addHalLink
      * @covers \Nocarrier\HalXmlRenderer::linksForXml
      */
     public function testLinkAttributesInXml()


### PR DESCRIPTION
This PR introduces the possibility to set a link directly by passing a `HalLink` instance.

While I am not totally happy with the naming **set** in `setLink()` (setting usually implies replacing some something rather than adding), it anyhow conforms to the schema used with `addResource()` / `setResource()`.

Additional tests aren't necessary as the old method `addLink()` under the hood now uses the new `setLink()` method, which therefore is covered automatically.