### PR TITLE
Make addResource throw exception if rel is a non-string

### DIFF
--- a/src/Nocarrier/Hal.php
+++ b/src/Nocarrier/Hal.php
@@ -185,6 +185,12 @@ class Hal
      */
     public function addResource($rel, \Nocarrier\Hal $resource = null, $forceArray = true)
     {
+        if (!is_string($rel)) {
+            throw new \InvalidArgumentException(
+                "Argument 1 passed to Hal::addResource() must be a string describing the resource relationship"
+            );
+        }
+
         $this->resources[$rel][] = $resource;
 
         if ($forceArray) {

--- a/tests/Hal/HalTest.php
+++ b/tests/Hal/HalTest.php
@@ -792,4 +792,11 @@ JSON;
         $json = json_decode($hal->asJson());
         $this->assertInternalType('array', $json->_embedded->foo->_embedded->bar);
     }
+
+    public function testErrorAddResource()
+    {
+        $this->setExpectedException('InvalidArgumentException');
+        $hal = new Hal();
+        $hal->addResource(new Hal());
+    }
 }


### PR DESCRIPTION
I had some problem troubleshooting a misstake I made when forgetting to specify the relationship when embedding a resource. In short the code

```php
(new Hal)->addResource(new Hal);
```

triggers an illegal offset type *warning* as objects can not be used as array keys, that you may or may not catch depending on your error setup. This pr makes `addResource` throw an exception if the first argument is not a string, as a help for people like me making this silly misstake...