### PR TITLE
Direct way of accessing data and resources

### DIFF
--- a/src/Nocarrier/Hal.php
+++ b/src/Nocarrier/Hal.php
@@ -234,10 +234,15 @@ class Hal
     /**
      * Return an array of data (key => value pairs) representing this resource.
      *
+     * @param null|string data key
      * @return array
      */
-    public function getData()
+    public function getData($key = null)
     {
+        if ($key) {
+            return isset($this->data[$key]) ? $this->data[$key] : null;
+        }
+
         return $this->data;
     }
 
@@ -280,6 +285,22 @@ class Hal
     }
 
     /**
+     * Return an array of Nocarrier\Hal objected embedded in this one.
+     *
+     * @return Hal
+     */
+    public function getResource($rel)
+    {
+        $resources = $this->getResources();
+
+        if (isset($resources[$rel])) {
+            return $resources[$rel];
+        }
+
+        return null;
+    }
+
+    /**
      * Return an array of Nocarrier\Hal objected embedded in this one. Each key
      * may contain an array of resources, or a single resource. For a
      * consistent approach, use getResources
@@ -299,10 +320,10 @@ class Hal
      */
     public function getFirstResource($rel)
     {
-        $resources = $this->getResources();
+        $resource = $this->getResource($rel);
 
-        if (isset($resources[$rel])) {
-            return $resources[$rel][0];
+        if ($resource) {
+            return $resource[0];
         }
 
         return null;

--- a/src/Nocarrier/Hal.php
+++ b/src/Nocarrier/Hal.php
@@ -240,7 +240,7 @@ class Hal
     public function getData($key = null)
     {
         if ($key) {
-            return isset($this->data[$key]) ? $this->data[$key] : null;
+            return isset($this->data[$key]) ? $this->data[$key] : array();
         }
 
         return $this->data;

--- a/tests/Hal/HalTest.php
+++ b/tests/Hal/HalTest.php
@@ -690,10 +690,8 @@ EOD;
         }
 JSON;
         $resources = Hal::fromJson($sample, 1)->getResources();
-        $data = $resources['item'][0]->getData();
-        $this->assertEquals('value1', $data['key']);
-        $data = $resources['item'][1]->getData();
-        $this->assertEquals('value2', $data['key']);
+        $this->assertEquals('value1', $resources['item'][0]->getData('key'));
+        $this->assertEquals('value2', $resources['item'][1]->getData('key'));
     }
 
     public function testHalJsonDecodeWithSingleEmbeddedItem()


### PR DESCRIPTION
While dealing with Hal objects I thought it could be a bit easier to access data attributes and specific resources. Some examples:

``` php
// current way
$data = $resouce->getData();
$title = $data['title'];

// alternative way
$title = $resource->getData('title');
```

The same goes for fetching a specific resource:

``` php
// current way
$resources = $hal->getResources();
$images = $resources['images'];

// alternative way
$images = $hal->getResource('images');
```

This change is being useful for me and maybe it can be useful for others as well.
