### PR TITLE
Fix return type in documentation

### DIFF
--- a/src/Nocarrier/Hal.php
+++ b/src/Nocarrier/Hal.php
@@ -318,7 +318,7 @@ class Hal
      * Get the first link for a given rel. Useful if you're only expecting
      * one link, or you don't care about subsequent links
      *
-     * @return Hal
+     * @return HalLink
      */
     public function getFirstLink($rel)
     {


### PR DESCRIPTION
While using your library I found this tiny mistake in the documentation, which gave me linting problems when I tried to do: 
``` $resource->addHalLink('magic', $magicResource->getFirstLink('self')); ```