### PR TITLE
Fix return type for HalRenderer

### DIFF
--- a/src/Hal.php
+++ b/src/Hal.php
@@ -379,7 +379,7 @@ class Hal
      *   Enable pretty-printing.
      * @param bool $encode
      *   Run through json_encode
-     * @return string
+     * @return string|array
      */
     public function asJson($pretty = false, $encode = true)
     {

--- a/src/HalJsonRenderer.php
+++ b/src/HalJsonRenderer.php
@@ -26,7 +26,7 @@ class HalJsonRenderer implements HalRenderer
      * @param \Nocarrier\Hal $resource
      * @param bool $pretty
      * @param bool $encode
-     * @return string
+     * @return string|array
      */
     public function render(Hal $resource, $pretty, $encode = true)
     {

--- a/src/HalRenderer.php
+++ b/src/HalRenderer.php
@@ -22,7 +22,7 @@ interface HalRenderer
     /**
      * Render the Hal resource in the appropriate form.
      *
-     * Returns a string representation of the resource.
+     * Returns a string (with $encode=true) or array (with $encode=false) representation of the resource.
      *
      * @param \Nocarrier\Hal $resource
      * @param boolean $pretty


### PR DESCRIPTION
The return type of `render` is now `string`, but that's only when `$encode=true`, otherwise it will (still) be an array.