### PR TITLE
chore: remove unused psr/link dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,8 +13,7 @@
   }
   ],
   "require": {
-    "php": "^8.2",
-    "psr/link": "^1.0"
+    "php": "^8.2"
   },
   "require-dev": {
     "phpunit/phpunit": "^11"


### PR DESCRIPTION
This PR removes `psr/link` from composer.json as it appears to be unused within the codebase.

**Reasoning:**

- **Unblocking Upgrades:** Currently, this package restricts users from upgrading to `psr/link ^2.0` in their own projects.

- **Code Audit:** I have scanned the repository and found no references to any classes or interfaces provided by `psr/link` (such as `LinkProviderInterface` or `LinkInterface`).

All existing tests pass, confirming that the removal does not impact the current functionality.

Once merged, tagging a new release would be highly beneficial for the community. It would allow users to adopt `psr/link 2.0 `in their own projects without being blocked by this package's current constraints.